### PR TITLE
changed shebang to '#!/usr/bin/env python3' to make this more portable

### DIFF
--- a/usr/lib/byobu/include/select-session.py
+++ b/usr/lib/byobu/include/select-session.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 #
 #    select-session.py
 #    Copyright (C) 2010 Canonical Ltd.


### PR DESCRIPTION
(specifically to fix a problem with using byobu on Mac with python3 installed via brew)